### PR TITLE
Add link to 2023 election page to nav

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,7 +8,7 @@
   url: /calendar/
 - title: Resources
   url: /resources/
-# - title: Search
-#   url: /search/
+- title: 2023 Election
+  url: /2023/election/
 - title: Contact
   url: mailto:steering@somervilleyimby.org?subject=From the website


### PR DESCRIPTION
When we’re ready, this can be merged in to add a link to the header nav for our 2023 election page